### PR TITLE
pattern matcher comment url skip fix

### DIFF
--- a/libsast/__init__.py
+++ b/libsast/__init__.py
@@ -8,7 +8,7 @@ from .scanner import Scanner
 __title__ = 'libsast'
 __authors__ = 'Ajin Abraham'
 __copyright__ = 'Copyright 2020 Ajin Abraham, OpenSecurity'
-__version__ = '1.3.5'
+__version__ = '1.3.6'
 __version_info__ = tuple(int(i) for i in __version__.split('.'))
 __all__ = [
     'Scanner',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def get_requires():
     requires = [
         'requests>=2.22.0',
         'pyyaml>=5.3',
-        'semgrep==0.34.0;platform_system!="Windows"',
+        'semgrep==0.35.0;platform_system!="Windows"',
     ]
     return requires
 


### PR DESCRIPTION
Fixes a bug that where comment replacer replaces a valid URL.
https://github.com/MobSF/Mobile-Security-Framework-MobSF/issues/1606

Semgrep version bump