### PR TITLE
Add support for wildcard file names

### DIFF
--- a/libsast/scanner.py
+++ b/libsast/scanner.py
@@ -15,6 +15,10 @@ from libsast.exceptions import (
     InvalidPathError,
 )
 
+from fnmatch import (
+    fnmatch,
+)
+
 
 class Scanner:
     def __init__(self, options: dict, paths: list) -> None:
@@ -85,7 +89,7 @@ class Scanner:
         """Check if we should scan the file."""
         ignore_paths = any(
             Path(pp).as_posix() in path.as_posix() for pp in self.ignore_paths)
-        ignore_files = path.name in self.ignore_filenames
+        ignore_files = any(fnmatch(path.name, ignore_filename) for ignore_filename in self.ignore_filenames)
         ignore_exts = path.suffix.lower() in self.ignore_extensions
         if (ignore_paths or ignore_files or ignore_exts):
             return False


### PR DESCRIPTION
Hi @ajinabraham,

I have a repository that has lots of test files in different folders that are named xxxxxTest.xxx. Currently there is no way to ignore them. This pull request adds a way to specify files to ignore using wildcards, e.g. `*Test*` will ignore any file name containing "Test".