### PR TITLE
Support multiple multiprocessing options

### DIFF
--- a/libsast/__init__.py
+++ b/libsast/__init__.py
@@ -12,7 +12,7 @@ year = str(datetime.now().year)
 __title__ = 'libsast'
 __authors__ = 'Ajin Abraham'
 __copyright__ = f'Copyright {year} Ajin Abraham, opensecurity.in'
-__version__ = '3.1.4'
+__version__ = '3.1.5'
 __version_info__ = tuple(int(i) for i in __version__.split('.'))
 __all__ = [
     'Scanner',

--- a/libsast/core_matcher/pattern_matcher.py
+++ b/libsast/core_matcher/pattern_matcher.py
@@ -25,7 +25,7 @@ class PatternMatcher:
         self.scan_rules = get_rules(options.get('match_rules'))
         self.show_progress = options.get('show_progress')
         self.cpu = options.get('cpu_core')
-        self.queue = options.get('queue')
+        self.multiprocessing = options.get('multiprocessing')
         exts = options.get('match_extensions')
         self.exts = [ext.lower() for ext in exts] if exts else []
         self.findings = {}
@@ -68,12 +68,20 @@ class PatternMatcher:
             return {}
         self.validate_rules()
 
-        if self.queue:
+        if self.multiprocessing == 'billiard':
             # Use billiard's pool for CPU-bound regex (support queues)
             from billiard import Pool
             with Pool(processes=self.cpu) as cpu_executor:
                 # Run regex on file data
                 results = cpu_executor.map(
+                    self.pattern_matcher,
+                    file_contents,
+                )
+        elif self.multiprocessing == 'thread':
+            # Use a ThreadPool for regex check
+            with ThreadPoolExecutor() as io_executor:
+                # Run regex on file data
+                results = io_executor.map(
                     self.pattern_matcher,
                     file_contents,
                 )

--- a/libsast/scanner.py
+++ b/libsast/scanner.py
@@ -26,7 +26,7 @@ class Scanner:
             'ignore_paths': [],
             'show_progress': False,
             'cpu_core': 1,
-            'queue': False,
+            'multiprocessing': 'default',
             # Overwrite with options from invocation
             **(options or {}),
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "libsast"
-version = "3.1.4"
+version = "3.1.5"
 description = "A generic SAST library built on top of semgrep and regex"
 keywords = ["libsast", "SAST", "Python SAST", "SAST API", "Regex SAST", "Pattern Matcher"]
 authors = ["Ajin Abraham <ajin@opensecurity.in>"]


### PR DESCRIPTION
Multiprocessing has issues in AWS Lambda and with Python task Queues such as Celery and Django-Q.
Allow to choose between `ProcessPoolExecutor`, `ThreadPoolExecutor` and `billiard`